### PR TITLE
Various corrections (some "possibly controversial")

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 		object-oriented design came from seeing the work of the sixties as something
 		more than a "better old thing."  This is, more than a better way: to do mainframe
 		computing; for end-users to invoke functionality; to make data structures more
-		abstract.  Instead the promise of exponential growth in computing /$/ volume
+		abstract.  Instead the promise of exponential growth in computing/$/volume <!-- sic -->
 		demanded that the sixties be regarded as "<i>almost</i> a new thing" and to find out
 		what the actual "new things" might be.  For example, one would compute with a
 		handheld "Dynabook" in a way that would not be possible on a shared mainframe;
@@ -592,7 +592,7 @@
 
 		<p>
 		As in Simula, a coroutining control structure [Conway, 1963] was used as a way to suspend and
-		resume objects.  Persistent objects like files and documents were treated as suspended processes and
+		resume objects.  Persistant<!-- sic --> objects like files and documents were treated as suspended processes and
 		were organized according to their Algol-like static variable scopes.  These were shown on the screen
 		and could be opened by pointing at them.  Coroutining was also used as a control structure for looping.
 		A single operator <b>while</b> was used to test the generators which returned <b>false</b> when unable to
@@ -637,7 +637,7 @@
 		and it was the first time I heard Marvin Minsky speak.  He put forth a terrific diatribe against
 		traditional education methods, and from him I heard the ideas of Piaget and Papert for the first time.
 		Marvin's talk was about how we think about complex situations and why schools are really bad
-		places to learn these skills.  He didn't have to make any claims about computers+kids to make his
+		places to learn these skills.  He didn't have to make any claims about computers+kids<!-- sic --> to make his
 		point.  It was clear that education and learning had to be rethought in the light of 20th century 
 		cognitive psychology and how good thinkers really think.  Computing enters as a new representation system
 		with new and useful metaphors for dealing with complexity, especially of systems [Minsky 70].
@@ -841,7 +841,7 @@
 		sight unseen a few years before) was horrified at the idea of their main competitor's computer being
 		used in the lab.  They balked.  The newly formed PARC group had a meeting in which it was decided
 		that it would take about three years to do a good operating system for the XDS SIGMA-7 but that we
-		could <i>build</i> "our own PDP-10" in a year.  My reaction was "Holy cow!"  In fact, they pulled it it off with 
+		could <i>build</i> "our own'PDP-10'<!-- sic --> in a year.  My reaction was "Holy cow!".<!-- sic -->  In fact, they pulled it it off with
 		considerable panache.  MAXC was actually a microcoded emulation of the PDP-10 that used for the first
 		time the new integrated chip memories (1K bits!) instead of core memory.  Having practical in house
 		experience with both of these new technologies was critical for the more radical systems to come.
@@ -1037,7 +1037,7 @@ to :robot 'pickup' :block
 		</p>
 		<p>
 		One part of the perceived beauty of mathematics has to do with a wondrous synergy between parsimony,
-		generality, enlightenment, and finesse.  For example, the Pythagorean Theorem is expressible
+		generality, enlightenment, and finesse.  For example, the Pythagorean Theorem is expressable<!-- sic -->
 		in a single line, is true for all of the infinite number of right triangles, is incredibly useful in 
 		understanding many other relationships, and can be shown by a few simple but profound steps.
 		</p>
@@ -1348,7 +1348,7 @@ to :robot 'pickup' :block
 		</p>
 		<p>
 		One of the styles retained from Smalltalk-71 was the comingling of function and class ideas.  In
-		other works, Smalltalk-72 classes looked like and could be used as functions, but it was easy to
+		other works<!-- sic -->, Smalltalk-72 classes looked like and could be used as functions, but it was easy to
 		produce an instance (a kind of closure) by using the object ISNEW.  Thus factorial could be written
 		"extensionally" as:
 		</p>
@@ -1415,7 +1415,7 @@ Pair :h :t
 		system going to do it right, and opted for the style that is
 		still in use today, which is more like "2&frac14;D".  Windows
 		were perhaps the most redesigned and reimplemented class in Smalltalk because we didn't quite have enough
-		compute power to just do the continual viewing to
+		compute<!-- sic --> power to just do the continual viewing to
 		"world coordinates" and refereshing that my former Utah
 		colleagues were starting to experiment with on the flight
 		simulator projects at Evans &amp; Sutherland.  This is a simple,
@@ -1541,7 +1541,7 @@ Pair :h :t
 		programming (no, we hadn't quite forgotten).  One
 		programmed by showing the system how changes should be made, much as one would illustrate on a 
 		blackboard with another programmer.  This program
-		became the starting place from which many subsequent "programming by example" systems took off.
+		became the starting place from which many subsequent <!-- sic missing quote -->programming by example" systems took off.
 		</p>
 		<p>
 		I should say something about the size of these 
@@ -1557,7 +1557,7 @@ Pair :h :t
 		</p>
 		<p>
 		Given its roots in simulation languages, it was easy
-		to write in a few pages, Simpula, a simple version of
+		to write in a few pages,<!-- sic comma --> Simpula, a simple version of
 		the SIMULA sequencing set approach to scheduling.  By
 		this time we had decided that coroutines could be
 		more cleanly be rendered by scheduling individual
@@ -1606,7 +1606,7 @@ then case
 		improvements which included providing a real "messenger" object, message dictionaries for classes 
 		(a step towards real class objects), Diana Merry's bitblt (the now famous 2D graphics operator for
 		bitmap graphics) redesigned by Dan and implemented in microcode, and a better, more general 
-		window interface.  Dave Robson while a student at UC Irvine had heard of our project and made a pretty
+		window interface.  Dave Robson while a student at UC<!-- sic no space -->Irvine had heard of our project and made a pretty
 		good stab at implementing an OOPL.  We invited him for a summer and never let him go back&mdash;he was
 		a great help in formulating an official semantics for Smalltalk.
 		</p>
@@ -1696,7 +1696,7 @@ then case
 		</p>
 		<p>
 		Perhaps the most important principle&mdash;again derived from operating system architectures&mdash;is that
-		when you give someone a structure, rarely do you want them to have unlimited privileges with it.
+		when you give someone a structure, rarely do you want them to have unlimited privledges<!-- sic --> with it.
 		Just doing type-matching isn't even close to what's needed.  Nor is it terribly useful to have some
 		objects protected and others not.  Make them all first class citizens and protect all.
 		</p>
@@ -2150,7 +2150,7 @@ ISNEW    &raquo;    (SELF undraw. 'size &lt;- size + :. SELF draw)</i></pre>
 
 			<p>
 			Xerox <u>must</u> take these several points seriously if it is to survive and prosper in its new
-			business are of information media.  If it does, the company has an excellent chance for several reasons:
+			business are<!-- sic --> of information media.  If it does, the company has an excellent chance for several reasons:
 			</p>
 			<ul>
 				<li>Xerox has the financial base to cover the large development costs of a small number of very
@@ -2238,7 +2238,7 @@ ISNEW    &raquo;    (SELF undraw. 'size &lt;- size + :. SELF draw)</i></pre>
 		windows, etc., and Adele and  I designed most of the
 		experiments.  Beyond that, Ted Kaehler, and visitor
 		Ron Baecker made highly valuable contributions.
-		Dave Smith designed, SmallStar, the prototype iconic
+		Dave Smith designed,<!-- sic comma --> SmallStar, the prototype iconic
 		interface for the Xerox Star product [Smith 83].
 		</p>
 		<p>
@@ -2439,7 +2439,7 @@ ISNEW    &raquo;    (SELF undraw. 'size &lt;- size + :. SELF draw)</i></pre>
 		Pat Winston's 2nd order models).
 		</p>
 		<p>
-		Meanwhile, the <i>NoteTaker</i> was getting realler, bigger,
+		Meanwhile, the <i>NoteTaker</i> was getting realler<!-- sic -->, bigger,
 		and slower.  By this time the Western Digital emulation-style
 		chips I hoped to used showed signs of being "diffusion-ware," and 
 		did not look like they would really show
@@ -2722,7 +2722,7 @@ ISNEW    &raquo;    (SELF undraw. 'size &lt;- size + :. SELF draw)</i></pre>
 		</p>
 		<p>
 		While justly applauding Dan, Adele and the others that made Smalltalk possible, we must wonder
-		at the same time: where are the Dans and the Adeles of the '80s and '90s that will take us to the
+		at the same time: where are the Dans and the Adeles of the '80s and '90s)<!-- sic --> that will take us to the
 		next stage?
 		</p>
                 <img src="Images/byte.png" alt="Byte Magazine, August 1981" width="281" height="358">


### PR DESCRIPTION
The first commit contains all the changes that are unambiguous improvements: the HTML was wrong, and the original was right. These are mostly simple spelling mistakes / wrong word used, and some missing or incorrect punctuation.

The second commit contains changes to make the HTML version match the original, even though the original was the one with the errors. I call these "possibly controversial" corrections, because they actually add more typos to the HTML version. I made this commit in case the goal is to faithfully reproduce the original document, including its faults. If that is not the goal, feel free to omit the second commit.

The second commit also adds "<!-- sic -->" comments to mark areas in the HTML where errors in the original document were accurately reproduced.
