### PR TITLE
Removes an extra 's'

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,7 +471,7 @@
 		<p>
 		But EULER was enough of "an almost new thing" to suggest that the same techniques be applied to
 		simplify Simula.  The EULER compiler was a part of its formal definition and made a simple conversion
-		into 85000-like byte-codes.  This was appealing because it s suggested that Ed's little machine could
+		into 85000-like byte-codes.  This was appealing because it suggested that Ed's little machine could
 		run byte-codes emulated in the longish slow microcode that was then possible.  The EULER compiler
 		however, was tortuously rendered in an "extended precedence" grammar that actually required
 		concessions in the language syntax (e.g. "," could only be used in one role because the precedence


### PR DESCRIPTION
Removes an extra 's' from the second paragraph of the FLEX machine section (3rd page of PDF).
