### PR TITLE
Table of contents missing its font size and stroke weight

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,26 +112,26 @@
 	<h2 align="center">Table of Contents</h2>
 
           <ul>
-            <li>Introduction <a href="#p2">2</a></li>
+            <h3><li>Introduction <a href="#p2">2</a></li></h3>
 
-	    <li>I. 1960-66&mdash;Early OOP and other formative ideas of the sixties
+	    <h3><li>I. 1960-66&mdash;Early OOP and other formative ideas of the sixties
               <a href="#p4">4</a>
-              <ul>
+              <ul></h3>
 		<li>B220 File System</li>
 		<li>SketchPad &amp; Simula</li>
               </ul>
             </li>
 
-	    <li>II 1967-69&mdash;The FLEX Machine, an OOP-based personal computer
+	    <h3><li>II 1967-69&mdash;The FLEX Machine, an OOP-based personal computer
               <a href="#p6">6</a>
-              <ul>
+              <ul></h3>
                 <li>Doug Englebart and NLS</li>
 		<li>Plasma Panel, GRAIL, LOGO, Dynabook</li>
               </ul>
             </li>
 
-	    <li>III. 1970-72&mdash;Xerox PARC <a href="#p12">12</a>
-              <ul>
+	    <h3><li>III. 1970-72&mdash;Xerox PARC <a href="#p12">12</a>
+              <ul></h3>
                 <li>KiddiKomp</li>
 		<li>miniCOM</li>
 		<li>Smalltalk-71</li>
@@ -142,9 +142,9 @@
               </ul>
             </li>
 
-	    <li>IV. 1972-76&mdash;Xerox PARC: The first real Smalltalk (-72)
+	    <h3><li>IV. 1972-76&mdash;Xerox PARC: The first real Smalltalk (-72)
               <a href="#p17">17</a>
-              <ul>
+              <ul></h3>
 	        <li>The two bets: birth of Smalltalk and Interim Dynabook</li>
 	        <li>Smalltalk-72 Principles</li>
 	        <li>The Smalltalk User Interface</li>
@@ -154,8 +154,8 @@
               </ul>
             </li>
 
-	    <li>V. 1976-80&mdash;The first modern Smalltalk (-76) <a href="#p29">29</a>
-              <ul>
+	    <h3><li>V. 1976-80&mdash;The first modern Smalltalk (-76) <a href="#p29">29</a>
+              <ul><h3>
 		<li>"Let's burn our disk packs"</li>
 		<li>The Notetaker</li>
 		<li>Smalltalk-76</li>
@@ -166,19 +166,19 @@
               </ul>
             </li>
 
-	    <li>VI. 1980-83&mdash;The release version of Smalltalk (-80) <a href="#p38">38</a>
-              <ul>
+	    <h3><li>VI. 1980-83&mdash;The release version of Smalltalk (-80) <a href="#p38">38</a>
+              <ul></h3>
 	        <li>Transformations</li>
 	        <li><a href="#coda">Coda</a></li>
               </ul>
             </li>
 
-	    <li>References Cited in Text <a href="#p41">41</a></li>
-	    <li>Appendix I: KiddiKomp Memo <a href="#p45">45</a></li>
-	    <li>Appendix II: Smalltalk-72 Interpreter Design <a href="#p47">47</a></li>
-	    <li>Appendix III: Acknowledgments <a href="#p50">50</a></li>
-	    <li>Appendix IV: Event Driven Loop Example <a href="#p53">53</a></li>
-	    <li>Appendix V: Smalltalk-76 Internal Structures <a href="#p54">54</a></li>
+	    <h3><li>References Cited in Text <a href="#p41">41</a></li></h3>
+	    <h3><li>Appendix I: KiddiKomp Memo <a href="#p45">45</a></li></h3>
+	    <h3><li>Appendix II: Smalltalk-72 Interpreter Design <a href="#p47">47</a></li></h3>
+	    <h3><li>Appendix III: Acknowledgments <a href="#p50">50</a></li></h3>
+	    <h3><li>Appendix IV: Event Driven Loop Example <a href="#p53">53</a></li></h3>
+	    <h3><li>Appendix V: Smalltalk-76 Internal Structures <a href="#p54">54</a></li></h3>
 
           </ul>
 


### PR DESCRIPTION
The alignment of the first two items "Introduction and item "I" is not equivalent to that which follows. This is unintentional, and I don't know a fix at the current moment