### PR TITLE
Correct Gabe Groner's name

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,7 +664,7 @@
 		This was GRAIL, the graphical followon to JOSS.  The
 		first tablet (the famous RAND tablet) was invented by
 		Tom Ellis [Davis 1964] in order to capture human 
-		gestures, and Gave Groner wrote a program to efficiently
+		gestures, and Gabe Groner wrote a program to efficiently
 		recognize and respond to them [Groner 1966].  Though
 		everything was fastened with bubble gum and the 
 		system crashed often, I have never forgotten my first interactions


### PR DESCRIPTION
Correct Gabe Groner's name. This was validated against the [original scan](https://raw.githubusercontent.com/worrydream/EarlyHistoryOfSmalltalk/master/SmalltalkHistoryHOPL-scanned-2015-07-16.pdf).

Thanks for this resource!